### PR TITLE
Use images by astral instead of pure distributions

### DIFF
--- a/docker/bot/Dockerfile.bot
+++ b/docker/bot/Dockerfile.bot
@@ -1,14 +1,12 @@
-FROM python:alpine3.17
+FROM ghcr.io/astral-sh/uv:0.5.5-python3.12-alpine
 
 RUN apk update && \
     apk upgrade && \
     apk add --no-cache ffmpeg && \
-    apk add make bash curl
+    apk add make bash
 
 COPY . .
 
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-
-RUN /root/.cargo/bin/uv pip install --system -r bot/requirements.txt
+RUN uv pip install --system -r bot/requirements.txt
 
 CMD [ "python3", "-u", "bot" ]

--- a/docker/inference-server/Dockerfile.inference-server
+++ b/docker/inference-server/Dockerfile.inference-server
@@ -1,14 +1,8 @@
-FROM python:3.11
-
-RUN apt update && \
-    apt upgrade -y && \
-    apt install curl -y
+FROM ghcr.io/astral-sh/uv:0.5.5-python3.12-bookworm-slim
 
 COPY . .
 
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-
-RUN /root/.cargo/bin/uv pip install --system -r inference_server/requirements.txt
+RUN uv pip install --system -r inference_server/requirements.txt
 
 EXPOSE 9090:9090
 


### PR DESCRIPTION
Fix the build of docker images as the place of `uv` installation sometimes changes when just using default installation script from nightly release